### PR TITLE
Load liblas and liblapack with a cling pragma

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ install(FILES ${XTENSOR_BLAS_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtensor-blas)
 
 install(DIRECTORY ${INCLUDE_DIR}/xtensor-blas/flens/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xtensor-blas/flens)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
 set(XTENSOR_BLAS_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for xtensor-blasConfig.cmake")

--- a/include/xtensor-blas/xblas_config.hpp
+++ b/include/xtensor-blas/xblas_config.hpp
@@ -21,6 +21,9 @@
 #define BLAS_IDX int
 #endif
 
+#pragma cling load("libblas")
+#pragma cling load("liblapack")
+
 namespace xt
 {
     using XBLAS_INDEX = int;

--- a/include/xtensor-blas/xblas_utils.hpp
+++ b/include/xtensor-blas/xblas_utils.hpp
@@ -9,7 +9,7 @@
 #ifndef XBLAS_UTILS_HPP
 #define XBLAS_UTILS_HPP
 
-#include "flens/cxxblas/typedefs.h"
+#include "cxxblas/typedefs.h"
 #include "xtensor/xutils.hpp"
 
 namespace xt

--- a/include/xtensor-blas/xlapack.hpp
+++ b/include/xtensor-blas/xlapack.hpp
@@ -18,7 +18,7 @@
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xutils.hpp"
 
-#include "flens/cxxlapack/cxxlapack.cxx"
+#include "cxxlapack/cxxlapack.cxx"
 
 #include "xtensor-blas/xblas_config.hpp"
 #include "xtensor-blas/xblas_utils.hpp"


### PR DESCRIPTION
`xtensor-blas` requires blas and lapack runtimes.

For these runtimes to be loaded by cling when including an xtensor-blas header, we need to use

```cpp
#pragma cling load("libblas")
#pragma cling load("liblapack")
```

Also, cling is confused by the two include paths `#include "flens/cxxblas/foobar.h` and `#include <cxxblas/foobar.h>`. This changes the CMakelist to use the latter only. Not using the former so that we don't need to modify the flens headers that we vendor.

Screenshot of xtensor-blas working in xeus-cling after this change:

![screenshot from 2017-08-09 16-14-02](https://user-images.githubusercontent.com/2397974/29126378-7e4c3ec2-7d1e-11e7-8636-4e79bb904c9d.png)
