### PR TITLE
Make cblas default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,10 @@ set(XTENSOR_BLAS_HEADERS
 )
 
 OPTION(CXXBLAS_DEBUG "print cxxblas debug information" OFF)
-OPTION(HAVE_CBLAS "use cblas" ON)
+OPTION(USE_FLENS_BLAS "use FLENS generic implementation instead of cblas" OFF)
 
-if(HAVE_CBLAS)
-  add_definitions(-DHAVE_CBLAS=1)
+if(USE_FLENS_BLAS)
+  add_definitions(-DUSE_FLENS_BLAS=1)
 endif()
 
 if (CXXBLAS_DEBUG)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -44,7 +44,9 @@ A package for xtensor-blas is available on the conda package manager.
 From source with cmake
 ----------------------
 
-You can install ``xtensor-blas`` from source with cmake. On Unix platforms, from the source directory:
+You can install ``xtensor-blas`` from source with cmake.
+Note that you need to have a BLAS installation available (e.g. OpenBLAS, MKL ...).
+On Unix platforms, from the source directory:
 
 .. code::
 

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -16,8 +16,8 @@ with conda is ``OpenBLAS``, but other options, such as ``MKL`` are available
 on conda, too. If xtensor-blas was not installed from conda, the user has
 to manually verify that a BLAS and `LAPACK <https://en.wikipedia.org/wiki/LAPACK>`_
 implementation is available.
-Additionally, the compile time define ``-DHAVE_CBLAS`` should be enabled,
-otherwise FLENS will use the slower internal implementation.
+If you want to fallback to a slower, more generic BLAS implementation, you can use
+the compile time define ``-DUSE_FLENS_BLAS``.
 
 In order to link against ``OpenBLAS`` from CMake, the following lines have
 to be added to the ``CMakeLists.txt`` file.

--- a/include/xtensor-blas/xblas_config.hpp
+++ b/include/xtensor-blas/xblas_config.hpp
@@ -13,6 +13,10 @@
 #define XTENSOR_BLAS_VERSION_MINOR 12
 #define XTENSOR_BLAS_VERSION_PATCH 0
 
+#ifndef USE_FLENS_BLAS
+#define HAVE_CBLAS 1
+#endif
+
 #ifndef USE_CXXLAPACK
 #define USE_CXXLAPACK
 #endif

--- a/include/xtensor-blas/xblas_config_cling.hpp.in
+++ b/include/xtensor-blas/xblas_config_cling.hpp.in
@@ -13,7 +13,13 @@
 #pragma cling add_library_path(@XTENSOR_BLAS_CLING_LIBRARY_DIR_32@)
 #pragma cling add_library_path(@XTENSOR_BLAS_CLING_LIBRARY_DIR@)
 
+#if !defined(XCLING_DISABLE_BLAS)
+
+#define HAVE_CBLAS 1
+
 #pragma cling load("libblas")
 #pragma cling load("liblapack")
+
+#endif
 
 #endif


### PR DESCRIPTION
This activates `USE_CBLAS` and adds a compile time option `USE_FLENS_BLAS` to optionally deactivate cblas.