### PR TITLE
Implement Tensordot

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -12,7 +12,7 @@ Defined in ``xtensor-blas/xlinalg.hpp``
 
 The functions here are closely modeled after NumPy's linalg package.
 
-Matrix and vector products
+Matrix, vector and tensor products
 --------------------------
 
 .. doxygenfunction:: xt::linalg::dot
@@ -28,6 +28,12 @@ Matrix and vector products
     :project: xtensor-blas
 
 .. doxygenfunction:: xt::linalg::kron
+    :project: xtensor-blas
+
+.. doxygenfunction:: xt::linalg::tensordot(const xexpression<T>&, const xexpression<O>&, std::size_t)
+    :project: xtensor-blas
+
+.. doxygenfunction:: xt::linalg::tensordot(const xexpression<T>&, const xexpression<O>&, const std::vector<std::size_t>&, const std::vector<std::size_t>&)
     :project: xtensor-blas
 
 Decompositions

--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -1562,7 +1562,7 @@ namespace linalg
         }
         else
         {
-          // Sum of products over last n axes of A and the first n axis of b
+            // Sum of products over last n axes of A and the first n axis of b
             XTENSOR_ASSERT(a.dimension() >= naxes);
             XTENSOR_ASSERT(b.dimension() >= naxes);
 
@@ -1605,11 +1605,13 @@ namespace linalg
             xarray<value_type, O::static_layout> b_mat = b;
             b_mat.reshape({sum_len, keep_b_len});
             result = dot(a_mat, b_mat);
-            if(result_shape.empty()){
-              result.reshape({1});
+            if(result_shape.empty())
+            {
+                result.reshape({1});
             }
-            else{
-              result.reshape(result_shape);
+            else
+            {
+                result.reshape(result_shape);
             }
 
         }
@@ -1652,20 +1654,19 @@ namespace linalg
             // first pass if i is not in ax_a, add to newaxes_a
             if (a_ax_it == ax_a.end())
             {
-               newaxes_a.push_back(i);
+                newaxes_a.push_back(i);
             }
         }
         for (auto& a_ax_it : ax_a)
         {
-          newaxes_a.push_back(a_ax_it);
-
+            newaxes_a.push_back(a_ax_it);
         }
 
         // Move the axes to sum over to the start of b
         xt::dynamic_shape<std::size_t> newaxes_b;
         for(auto& b_ax_it : ax_b)
         {
-          newaxes_b.push_back(b_ax_it);
+            newaxes_b.push_back(b_ax_it);
         }
         for (std::size_t i = 0; i < b.dimension(); ++i)
         {
@@ -1673,7 +1674,7 @@ namespace linalg
             // seccond pass if i is not in ax_b add to newaxes_b
             if (b_ax_it == ax_b.end())
             {
-              newaxes_b.push_back(i);
+                newaxes_b.push_back(i);
             }
         }
         auto a_t = xt::transpose(a, newaxes_a);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,7 @@ set(XTENSOR_BLAS_TESTS
     test_lapack.cpp
     test_linalg.cpp
     test_dot.cpp
+    test_tensordot.cpp
 )
 
 set(XTENSOR_BLAS_TARGET test_xtensor_blas)

--- a/test/test_tensordot.cpp
+++ b/test/test_tensordot.cpp
@@ -10,245 +10,243 @@ namespace xt
 {
     TEST(xtensordot, outer_product)
     {
-      xarray<double> a = xt::ones<double>({3,3,3});
-      xarray<double> b = xt::ones<double>({2,2}) * 5.0;
-      xarray<double> e1 = xt::ones<double>({3,3,3,2,2}) * 5.0;
+        xarray<double> a = xt::ones<double>({3,3,3});
+        xarray<double> b = xt::ones<double>({2,2}) * 5.0;
+        xarray<double> e1 = xt::ones<double>({3,3,3,2,2}) * 5.0;
 
-      auto r1 = linalg::tensordot(a, b, 0);
-      EXPECT_EQ(e1, r1);
+        auto r1 = linalg::tensordot(a, b, 0);
+        EXPECT_EQ(e1, r1);
     }
 
     TEST(xtensordot, outer_product_cm)
     {
-      xarray<float, layout_type::column_major> a = xt::ones<float>({3,3,3});
-      xarray<float, layout_type::column_major> b = xt::ones<float>({2,2}) * 5.0;
-      xarray<float, layout_type::column_major> e1 = xt::ones<float>({3,3,3,2,2}) * 5.0;
+        xarray<float, layout_type::column_major> a = xt::ones<float>({3,3,3});
+        xarray<float, layout_type::column_major> b = xt::ones<float>({2,2}) * 5.0;
+        xarray<float, layout_type::column_major> e1 = xt::ones<float>({3,3,3,2,2}) * 5.0;
 
-      auto r1 = linalg::tensordot(a, b, 0);
-      EXPECT_EQ(e1, r1);
+        auto r1 = linalg::tensordot(a, b, 0);
+        EXPECT_EQ(e1, r1);
 
     }
 
     TEST(xtensordot, outer_product_mixed_layout)
     {
-      xarray<float, layout_type::column_major> a = xt::ones<float>({3,3,3});
-      xarray<float> b = xt::ones<float>({2,2}) * 5.0;
-      xarray<float, layout_type::column_major> e1 = xt::ones<float>({3,3,3,2,2}) * 5.0;
+        xarray<float, layout_type::column_major> a = xt::ones<float>({3,3,3});
+        xarray<float> b = xt::ones<float>({2,2}) * 5.0;
+        xarray<float, layout_type::column_major> e1 = xt::ones<float>({3,3,3,2,2}) * 5.0;
 
-      auto r1 = linalg::tensordot(a, b, 0);
-      EXPECT_EQ(e1, r1);
+        auto r1 = linalg::tensordot(a, b, 0);
+        EXPECT_EQ(e1, r1);
 
-      xarray<float> e2 = xt::ones<float>({2,2,3,3,3}) * 5.0;
-      auto r2 = linalg::tensordot(b, a, 0);
-      EXPECT_EQ(e2, r2);
+        xarray<float> e2 = xt::ones<float>({2,2,3,3,3}) * 5.0;
+        auto r2 = linalg::tensordot(b, a, 0);
+        EXPECT_EQ(e2, r2);
 
     }
 
     TEST(xtensordot, inner_product)
     {
-      xarray<double> a = xt::ones<double>({3,3,2,2});
-      xarray<double> b = xt::ones<double>({2,2,10});
-      auto r1 = linalg::tensordot(a, b);
-      EXPECT_TRUE(all(equal(r1, 4)));
-      EXPECT_TRUE(r1.shape().size() == 3);
-      EXPECT_TRUE(r1.shape()[0] == 3);
-      EXPECT_TRUE(r1.shape()[1] == 3);
-      EXPECT_TRUE(r1.shape()[2] == 10);
+        xarray<double> a = xt::ones<double>({3,3,2,2});
+        xarray<double> b = xt::ones<double>({2,2,10});
+        auto r1 = linalg::tensordot(a, b);
+        EXPECT_TRUE(all(equal(r1, 4)));
+        EXPECT_TRUE(r1.shape().size() == 3);
+        EXPECT_TRUE(r1.shape()[0] == 3);
+        EXPECT_TRUE(r1.shape()[1] == 3);
+        EXPECT_TRUE(r1.shape()[2] == 10);
 
-      EXPECT_THROW(linalg::tensordot(a, b, 3), std::runtime_error);
-      EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
+        EXPECT_THROW(linalg::tensordot(a, b, 3), std::runtime_error);
+        EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
 
     }
 
     TEST(xtensordot, inner_product_cm)
     {
-      xarray<double, layout_type::column_major> a = xt::ones<double>({3,3,2,2});
-      xarray<double, layout_type::column_major> b = xt::ones<double>({2,2,10});
-      auto r1 = linalg::tensordot(a, b);
-      EXPECT_TRUE(all(equal(r1, 4)));
-      EXPECT_TRUE(r1.shape().size() == 3);
-      EXPECT_TRUE(r1.shape()[0] == 3);
-      EXPECT_TRUE(r1.shape()[1] == 3);
-      EXPECT_TRUE(r1.shape()[2] == 10);
+        xarray<double, layout_type::column_major> a = xt::ones<double>({3,3,2,2});
+        xarray<double, layout_type::column_major> b = xt::ones<double>({2,2,10});
+        auto r1 = linalg::tensordot(a, b);
+        EXPECT_TRUE(all(equal(r1, 4)));
+        EXPECT_TRUE(r1.shape().size() == 3);
+        EXPECT_TRUE(r1.shape()[0] == 3);
+        EXPECT_TRUE(r1.shape()[1] == 3);
+        EXPECT_TRUE(r1.shape()[2] == 10);
 
-      EXPECT_THROW(linalg::tensordot(a, b, 3), std::runtime_error);
-      EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
+        EXPECT_THROW(linalg::tensordot(a, b, 3), std::runtime_error);
+        EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
 
     }
 
     TEST(xtensordot, inner_product_mixed_layout)
     {
-      xarray<double> a = xt::ones<double>({3,3,2,2});
-      xarray<double, layout_type::column_major> b = xt::ones<double>({3,2,2,10});
-      auto r1 = linalg::tensordot(a, b, 3);
-      EXPECT_TRUE(all(equal(r1, 12.0)));
-      EXPECT_TRUE(r1.shape().size() == 2);
-      EXPECT_TRUE(r1.shape()[0] == 3);
-      EXPECT_TRUE(r1.shape()[1] == 10);
+        xarray<double> a = xt::ones<double>({3,3,2,2});
+        xarray<double, layout_type::column_major> b = xt::ones<double>({3,2,2,10});
+        auto r1 = linalg::tensordot(a, b, 3);
+        EXPECT_TRUE(all(equal(r1, 12.0)));
+        EXPECT_TRUE(r1.shape().size() == 2);
+        EXPECT_TRUE(r1.shape()[0] == 3);
+        EXPECT_TRUE(r1.shape()[1] == 10);
 
-      EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
+        EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
 
     }
 
     TEST(xtensordot, tuple_ax)
     {
-      xarray<double> a = {{{{0, 1},
-                            {2, 3},
-                            {4, 5}},
-                           {{6, 7},
-                            {8, 9},
-                            {10, 11}}},
-                          {{{12, 13},
-                            {14,15},
-                            {16,17}},
-                           {{18, 19},
-                            {20, 21},
-                            {22,23}}},
-                          {{{24,25},
-                            {26,27},
-                            {28,29}},
-                           {{30,31},
-                            {32,33},
-                            {34,35}}}};
-      xarray<double> b = xt::ones<double>({2, 3, 2, 3});
-      auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
-      xarray<double> e1 = {{66, 66, 66},
-                           {210,210,210},
-                           {354, 354, 354}};
-      EXPECT_EQ(r1, e1);
-      auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
-      xarray<double> e2 = xarray<double>::from_shape({1,1});
-      e2(0,0) = 630;
-      EXPECT_EQ(r2(0,0), e2(0,0));
+        xarray<double> a = {{{{0, 1},
+                              {2, 3},
+                              {4, 5}},
+                            {{6, 7},
+                              {8, 9},
+                              {10, 11}}},
+                            {{{12, 13},
+                              {14,15},
+                              {16,17}},
+                            {{18, 19},
+                              {20, 21},
+                              {22,23}}},
+                            {{{24,25},
+                              {26,27},
+                              {28,29}},
+                            {{30,31},
+                              {32,33},
+                              {34,35}}}};
+        xarray<double> b = xt::ones<double>({2, 3, 2, 3});
+        auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
+        xarray<double> e1 = {{66, 66, 66},
+                            {210,210,210},
+                            {354, 354, 354}};
+        EXPECT_EQ(r1, e1);
+        auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
+        xarray<double> e2 = xarray<double>::from_shape({1,1});
+        e2(0,0) = 630;
+        EXPECT_EQ(r2(0,0), e2(0,0));
     }
 
     TEST(xtensordot, tuple_ax_cm)
     {
-      xarray<double, layout_type::column_major> a = {{{{0, 1},
-                            {2, 3},
-                            {4, 5}},
-                           {{6, 7},
-                            {8, 9},
-                            {10, 11}}},
-                          {{{12, 13},
-                            {14,15},
-                            {16,17}},
-                           {{18, 19},
-                            {20, 21},
-                            {22,23}}},
-                          {{{24,25},
-                            {26,27},
-                            {28,29}},
-                           {{30,31},
-                            {32,33},
-                            {34,35}}}};
-      xarray<double, layout_type::column_major> b = xt::ones<double>({2, 3, 2, 3});
-      auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
-      xarray<double, layout_type::column_major> e1 = {{66, 66, 66},
-                           {210,210,210},
-                           {354, 354, 354}};
-      EXPECT_EQ(r1, e1);
-      auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
-      xarray<double, layout_type::column_major> e2 = xarray<double>::from_shape({1,1});
-      e2(0,0) = 630;
-      EXPECT_EQ(r2(0,0), e2(0,0));
+        xarray<double, layout_type::column_major> a = {{{{0, 1},
+                              {2, 3},
+                              {4, 5}},
+                            {{6, 7},
+                              {8, 9},
+                              {10, 11}}},
+                            {{{12, 13},
+                              {14,15},
+                              {16,17}},
+                            {{18, 19},
+                              {20, 21},
+                              {22,23}}},
+                            {{{24,25},
+                              {26,27},
+                              {28,29}},
+                            {{30,31},
+                              {32,33},
+                              {34,35}}}};
+        xarray<double, layout_type::column_major> b = xt::ones<double>({2, 3, 2, 3});
+        auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
+        xarray<double, layout_type::column_major> e1 = {{66, 66, 66},
+                            {210,210,210},
+                            {354, 354, 354}};
+        EXPECT_EQ(r1, e1);
+        auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
+        xarray<double, layout_type::column_major> e2 = xarray<double>::from_shape({1,1});
+        e2(0,0) = 630;
+        EXPECT_EQ(r2(0,0), e2(0,0));
 
     }
 
     TEST(xtensordot, tuple_ax_mixed_layout)
     {
-      xarray<double, layout_type::column_major> a = {{{{0, 1},
-                            {2, 3},
-                            {4, 5}},
-                           {{6, 7},
-                            {8, 9},
-                            {10, 11}}},
-                          {{{12, 13},
-                            {14,15},
-                            {16,17}},
-                           {{18, 19},
-                            {20, 21},
-                            {22,23}}},
-                          {{{24,25},
-                            {26,27},
-                            {28,29}},
-                           {{30,31},
-                            {32,33},
-                            {34,35}}}};
-      xarray<double> b = xt::ones<double>({2, 3, 2, 3});
-      auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
-      xarray<double, layout_type::column_major> e1 = {{66, 66, 66},
-                           {210,210,210},
-                           {354, 354, 354}};
-      EXPECT_EQ(r1, e1);
+        xarray<double, layout_type::column_major> a = {{{{0, 1},
+                              {2, 3},
+                              {4, 5}},
+                            {{6, 7},
+                              {8, 9},
+                              {10, 11}}},
+                            {{{12, 13},
+                              {14,15},
+                              {16,17}},
+                            {{18, 19},
+                              {20, 21},
+                              {22,23}}},
+                            {{{24,25},
+                              {26,27},
+                              {28,29}},
+                            {{30,31},
+                              {32,33},
+                              {34,35}}}};
+        xarray<double> b = xt::ones<double>({2, 3, 2, 3});
+        auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
+        xarray<double, layout_type::column_major> e1 = {{66, 66, 66},
+                            {210,210,210},
+                            {354, 354, 354}};
+        EXPECT_EQ(r1, e1);
 
-      auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
-      xarray<double, layout_type::column_major> e2 = {630};
+        auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
+        xarray<double, layout_type::column_major> e2 = {630};
 
-      EXPECT_EQ(r2, e2);
+        EXPECT_EQ(r2, e2);
     }
 
     TEST(xtensordot, view)
     {
 
-      xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
-      xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
+        xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
+        xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
 
-      xarray<int> e1 = {{ 34,  90, 146},
-                            { 46, 134, 222},
-                            { 58, 178, 298}};
+        xarray<int> e1 = {{ 34,  90, 146},
+                              { 46, 134, 222},
+                              { 58, 178, 298}};
 
-      auto res1 = linalg::tensordot(view(a, 0, all(), all(), all()),
-                                    view(b, 0, all(), all(), all()), {0, 2}, {1,2});
+        auto res1 = linalg::tensordot(view(a, 0, all(), all(), all()),
+                                      view(b, 0, all(), all(), all()), {0, 2}, {1,2});
 
-      EXPECT_EQ(res1, e1);
-      EXPECT_EQ(res1.dimension(), 2);
-      EXPECT_EQ(res1.shape()[0], 3);
-      EXPECT_EQ(res1.shape()[1], 3);
+        EXPECT_EQ(res1, e1);
+        EXPECT_EQ(res1.dimension(), 2);
+        EXPECT_EQ(res1.shape()[0], 3);
+        EXPECT_EQ(res1.shape()[1], 3);
     }
 
     TEST(xtensordot, strided_view_range)
     {
-      xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
-      xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
+        xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
+        xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
 
-      xarray<int> e1 = {{1064, 1144}, {1136, 1224}};
+        xarray<int> e1 = {{1064, 1144}, {1136, 1224}};
 
-      auto res1 = linalg::tensordot(strided_view(a, {range(0, 2), all(), range(0, 2), all()}),
-                                    strided_view(b, {range(0, 2), range(0,2), all(), all()}),
-                                    {0, 1, 2}, {0, 1, 2});
-      EXPECT_EQ(res1, e1);
-      EXPECT_EQ(res1.dimension(), 2);
-      EXPECT_EQ(res1.shape()[0], 2);
-      EXPECT_EQ(res1.shape()[1], 2);
+        auto res1 = linalg::tensordot(strided_view(a, {range(0, 2), all(), range(0, 2), all()}),
+                                      strided_view(b, {range(0, 2), range(0,2), all(), all()}),
+                                      {0, 1, 2}, {0, 1, 2});
+        EXPECT_EQ(res1, e1);
+        EXPECT_EQ(res1.dimension(), 2);
+        EXPECT_EQ(res1.shape()[0], 2);
+        EXPECT_EQ(res1.shape()[1], 2);
 
     }
 
     TEST(xtensordot, reducing_dim_view)
     {
-      xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
-      xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
+        xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
+        xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
 
 
-      xarray<int> e = {1589};
-      auto r = linalg::tensordot(view(a, 0, 1, all(), all()),
-                                 view(b, 2, all(), 1, all()));
-      EXPECT_EQ(r, e);
+        xarray<int> e = {1589};
+        auto r = linalg::tensordot(view(a, 0, 1, all(), all()),
+                                  view(b, 2, all(), 1, all()));
+        EXPECT_EQ(r, e);
 
     }
 
     TEST(xtensordot, reducing_dim_strided_view)
     {
-      xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
-      xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
+        xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
+        xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
 
 
-      xarray<int> e = {1589};
-      auto r = linalg::tensordot(strided_view(a, {0, 1, all(), all()}),
-                                    strided_view(b, {2, all(), 1, all()}));
-      EXPECT_EQ(r, e);
+        xarray<int> e = {1589};
+        auto r = linalg::tensordot(strided_view(a, {0, 1, all(), all()}),
+                                      strided_view(b, {2, all(), 1, all()}));
+        EXPECT_EQ(r, e);
 
     }
-
-
 }

--- a/test/test_tensordot.cpp
+++ b/test/test_tensordot.cpp
@@ -181,9 +181,74 @@ namespace xt
                            {210,210,210},
                            {354, 354, 354}};
       EXPECT_EQ(r1, e1);
+
       auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
-      xarray<double, layout_type::column_major> e2 = xarray<double>::from_shape({1,1});
-      e2(0,0) = 630;
-      EXPECT_EQ(r2(0,0), e2(0,0));
+      xarray<double, layout_type::column_major> e2 = {630};
+
+      EXPECT_EQ(r2, e2);
     }
+
+    TEST(xtensordot, view)
+    {
+
+      xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
+      xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
+
+      xarray<int> e1 = {{ 34,  90, 146},
+                            { 46, 134, 222},
+                            { 58, 178, 298}};
+
+      auto res1 = linalg::tensordot(view(a, 0, all(), all(), all()),
+                                    view(b, 0, all(), all(), all()), {0, 2}, {1,2});
+
+      EXPECT_EQ(res1, e1);
+      EXPECT_EQ(res1.dimension(), 2);
+      EXPECT_EQ(res1.shape()[0], 3);
+      EXPECT_EQ(res1.shape()[1], 3);
+    }
+
+    TEST(xtensordot, strided_view_range)
+    {
+      xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
+      xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
+
+      xarray<int> e1 = {{1064, 1144}, {1136, 1224}};
+
+      auto res1 = linalg::tensordot(strided_view(a, {range(0, 2), all(), range(0, 2), all()}),
+                                    strided_view(b, {range(0, 2), range(0,2), all(), all()}),
+                                    {0, 1, 2}, {0, 1, 2});
+      EXPECT_EQ(res1, e1);
+      EXPECT_EQ(res1.dimension(), 2);
+      EXPECT_EQ(res1.shape()[0], 2);
+      EXPECT_EQ(res1.shape()[1], 2);
+
+    }
+
+    TEST(xtensordot, reducing_dim_view)
+    {
+      xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
+      xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
+
+
+      xarray<int> e = {1589};
+      auto r = linalg::tensordot(view(a, 0, 1, all(), all()),
+                                 view(b, 2, all(), 1, all()));
+      EXPECT_EQ(r, e);
+
+    }
+
+    TEST(xtensordot, reducing_dim_strided_view)
+    {
+      xarray<int> a = reshape_view(arange<int>(3*2*3*2), {3,2,3,2});
+      xarray<int> b = reshape_view(arange<int>(3*3*2*2), {3,3,2,2});
+
+
+      xarray<int> e = {1589};
+      auto r = linalg::tensordot(strided_view(a, {0, 1, all(), all()}),
+                                    strided_view(b, {2, all(), 1, all()}));
+      EXPECT_EQ(r, e);
+
+    }
+
+
 }

--- a/test/test_tensordot.cpp
+++ b/test/test_tensordot.cpp
@@ -1,0 +1,189 @@
+#include "gtest/gtest.h"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xview.hpp"
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xstrided_view.hpp"
+
+#include "xtensor-blas/xlinalg.hpp"
+
+namespace xt
+{
+    TEST(xtensordot, outer_product)
+    {
+      xarray<double> a = xt::ones<double>({3,3,3});
+      xarray<double> b = xt::ones<double>({2,2}) * 5.0;
+      xarray<double> e1 = xt::ones<double>({3,3,3,2,2}) * 5.0;
+
+      auto r1 = linalg::tensordot(a, b, 0);
+      EXPECT_EQ(e1, r1);
+    }
+
+    TEST(xtensordot, outer_product_cm)
+    {
+      xarray<float, layout_type::column_major> a = xt::ones<float>({3,3,3});
+      xarray<float, layout_type::column_major> b = xt::ones<float>({2,2}) * 5.0;
+      xarray<float, layout_type::column_major> e1 = xt::ones<float>({3,3,3,2,2}) * 5.0;
+
+      auto r1 = linalg::tensordot(a, b, 0);
+      EXPECT_EQ(e1, r1);
+
+    }
+
+    TEST(xtensordot, outer_product_mixed_layout)
+    {
+      xarray<float, layout_type::column_major> a = xt::ones<float>({3,3,3});
+      xarray<float> b = xt::ones<float>({2,2}) * 5.0;
+      xarray<float, layout_type::column_major> e1 = xt::ones<float>({3,3,3,2,2}) * 5.0;
+
+      auto r1 = linalg::tensordot(a, b, 0);
+      EXPECT_EQ(e1, r1);
+
+      xarray<float> e2 = xt::ones<float>({2,2,3,3,3}) * 5.0;
+      auto r2 = linalg::tensordot(b, a, 0);
+      EXPECT_EQ(e2, r2);
+
+    }
+
+    TEST(xtensordot, inner_product)
+    {
+      xarray<double> a = xt::ones<double>({3,3,2,2});
+      xarray<double> b = xt::ones<double>({2,2,10});
+      auto r1 = linalg::tensordot(a, b);
+      EXPECT_TRUE(all(equal(r1, 4)));
+      EXPECT_TRUE(r1.shape().size() == 3);
+      EXPECT_TRUE(r1.shape()[0] == 3);
+      EXPECT_TRUE(r1.shape()[1] == 3);
+      EXPECT_TRUE(r1.shape()[2] == 10);
+
+      EXPECT_THROW(linalg::tensordot(a, b, 3), std::runtime_error);
+      EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
+
+    }
+
+    TEST(xtensordot, inner_product_cm)
+    {
+      xarray<double, layout_type::column_major> a = xt::ones<double>({3,3,2,2});
+      xarray<double, layout_type::column_major> b = xt::ones<double>({2,2,10});
+      auto r1 = linalg::tensordot(a, b);
+      EXPECT_TRUE(all(equal(r1, 4)));
+      EXPECT_TRUE(r1.shape().size() == 3);
+      EXPECT_TRUE(r1.shape()[0] == 3);
+      EXPECT_TRUE(r1.shape()[1] == 3);
+      EXPECT_TRUE(r1.shape()[2] == 10);
+
+      EXPECT_THROW(linalg::tensordot(a, b, 3), std::runtime_error);
+      EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
+
+    }
+
+    TEST(xtensordot, inner_product_mixed_layout)
+    {
+      xarray<double> a = xt::ones<double>({3,3,2,2});
+      xarray<double, layout_type::column_major> b = xt::ones<double>({3,2,2,10});
+      auto r1 = linalg::tensordot(a, b, 3);
+      EXPECT_TRUE(all(equal(r1, 12.0)));
+      EXPECT_TRUE(r1.shape().size() == 2);
+      EXPECT_TRUE(r1.shape()[0] == 3);
+      EXPECT_TRUE(r1.shape()[1] == 10);
+
+      EXPECT_THROW(linalg::tensordot(b, a), std::runtime_error);
+
+    }
+
+    TEST(xtensordot, tuple_ax)
+    {
+      xarray<double> a = {{{{0, 1},
+                            {2, 3},
+                            {4, 5}},
+                           {{6, 7},
+                            {8, 9},
+                            {10, 11}}},
+                          {{{12, 13},
+                            {14,15},
+                            {16,17}},
+                           {{18, 19},
+                            {20, 21},
+                            {22,23}}},
+                          {{{24,25},
+                            {26,27},
+                            {28,29}},
+                           {{30,31},
+                            {32,33},
+                            {34,35}}}};
+      xarray<double> b = xt::ones<double>({2, 3, 2, 3});
+      auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
+      xarray<double> e1 = {{66, 66, 66},
+                           {210,210,210},
+                           {354, 354, 354}};
+      EXPECT_EQ(r1, e1);
+      auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
+      xarray<double> e2 = xarray<double>::from_shape({1,1});
+      e2(0,0) = 630;
+      EXPECT_EQ(r2(0,0), e2(0,0));
+    }
+
+    TEST(xtensordot, tuple_ax_cm)
+    {
+      xarray<double, layout_type::column_major> a = {{{{0, 1},
+                            {2, 3},
+                            {4, 5}},
+                           {{6, 7},
+                            {8, 9},
+                            {10, 11}}},
+                          {{{12, 13},
+                            {14,15},
+                            {16,17}},
+                           {{18, 19},
+                            {20, 21},
+                            {22,23}}},
+                          {{{24,25},
+                            {26,27},
+                            {28,29}},
+                           {{30,31},
+                            {32,33},
+                            {34,35}}}};
+      xarray<double, layout_type::column_major> b = xt::ones<double>({2, 3, 2, 3});
+      auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
+      xarray<double, layout_type::column_major> e1 = {{66, 66, 66},
+                           {210,210,210},
+                           {354, 354, 354}};
+      EXPECT_EQ(r1, e1);
+      auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
+      xarray<double, layout_type::column_major> e2 = xarray<double>::from_shape({1,1});
+      e2(0,0) = 630;
+      EXPECT_EQ(r2(0,0), e2(0,0));
+
+    }
+
+    TEST(xtensordot, tuple_ax_mixed_layout)
+    {
+      xarray<double, layout_type::column_major> a = {{{{0, 1},
+                            {2, 3},
+                            {4, 5}},
+                           {{6, 7},
+                            {8, 9},
+                            {10, 11}}},
+                          {{{12, 13},
+                            {14,15},
+                            {16,17}},
+                           {{18, 19},
+                            {20, 21},
+                            {22,23}}},
+                          {{{24,25},
+                            {26,27},
+                            {28,29}},
+                           {{30,31},
+                            {32,33},
+                            {34,35}}}};
+      xarray<double> b = xt::ones<double>({2, 3, 2, 3});
+      auto r1 = linalg::tensordot(a, b, {1, 3, 2}, {0, 2, 1});
+      xarray<double, layout_type::column_major> e1 = {{66, 66, 66},
+                           {210,210,210},
+                           {354, 354, 354}};
+      EXPECT_EQ(r1, e1);
+      auto r2 = linalg::tensordot(a, b, {1, 3, 2, 0}, {0, 2, 1, 3});
+      xarray<double, layout_type::column_major> e2 = xarray<double>::from_shape({1,1});
+      e2(0,0) = 630;
+      EXPECT_EQ(r2(0,0), e2(0,0));
+    }
+}


### PR DESCRIPTION
This PR adds an implementation of tensordot. 

`numpy.tensordot` accepts two ways of specifying the `axes` argument. 
One where axes is an integer and specifies that the last (first) `axes` axes in `a` (`b`) will be those summed over. The other is where axes is a pair of tuples of the same length and the axes from the first tuple are those summed over for `a` and the axes from the second tuple are those summed over for `b`. 

## Small difference between numpy's syntax and xtensor's syntax.

I have implemented this as two overloads one, taking the single `naxes` argument which default to 2 (same as numpy), and the second overload taking two vectors, one for a and one for b. The resulting syntax is similar in appearance to that of numpy with one small exception. 

### Axes is a single integer:
No difference here. 
numpy: 
```python
np.tensordot(a, b) # default behavior axes = 2
np.tensordot(a, b, axes=3) # specify axes != 2
```
xtensor:
```c++
xt::linalg::tensordot(a, b) // calls first overload, default behavior naxes = 2
xt::linalg::tensordot(a, b, 3) // calls first  overload, specify naxes != 2
```

### Axes is specified using vectors/tuples (numpy/xtensor):
Here is the difference. In numpy axes is still one argument.
```python
np.tensordot(a, b, axes=((1,3),(2,3))) # axes is a pair of tuples
```
In my implementation for xtensor, axes is split into two arguments
```c++
xt::linalg::tensordot(a, b, {1,3}, {2,3})
```

Happy to add additional tests, or respond to any feedback about performance problems with my implementation (I was learning how the lazy evaluation of expressions works while I was writing this, so I am sure that I was over cautious with copies/forcing evaluation and there is probably room for performance improvements). 