### PR TITLE
Minor fix in xt::linalg::vdot()

### DIFF
--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -883,14 +883,7 @@ namespace linalg
         XTENSOR_ASSERT(db.dimension() == 1);
 
         common_type result = 0;
-        if (xtl::is_complex<typename T::value_type>::value)
-        {
-            blas::dot(da, db, result);
-        }
-        else
-        {
-            blas::dotu(da, db, result);
-        }
+        blas::dot(da, db, result);
 
         return result;
     }


### PR DESCRIPTION
We normally use `dot()` for non-complex number.