### PR TITLE
Fix for undeclared var in vdot

### DIFF
--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -876,8 +876,8 @@ namespace linalg
 
         using common_type = std::common_type_t<typename T::value_type, typename O::value_type>;
 
-        XTENSOR_ASSERT(da.derived_cast().dimension() == 1);
-        XTENSOR_ASSERT(db.derived_cast().dimension() == 1);
+        XTENSOR_ASSERT(a.derived_cast().dimension() == 1);
+        XTENSOR_ASSERT(b.derived_cast().dimension() == 1);
 
         common_type result = 0;
         blas::dot(a, b, result);

--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -1713,3 +1713,4 @@ namespace linalg
 }
 }
 #endif
+

--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -1713,4 +1713,3 @@ namespace linalg
 }
 }
 #endif
-


### PR DESCRIPTION
Looks like during a refactor the definition of `da` was lost. Looks like we mean to reference the inputs instead (at least, this seems to compile and work for me).