### PR TITLE
fix offset for negative strides in blas::dot

### DIFF
--- a/include/xtensor-blas/xblas.hpp
+++ b/include/xtensor-blas/xblas.hpp
@@ -83,12 +83,27 @@ namespace blas
         auto&& bd = view_eval<E2::static_layout>(b.derived_cast());
         XTENSOR_ASSERT(ad.dimension() == 1);
 
+        blas_index_t stride_a = stride_front(ad);
+        blas_index_t stride_b = stride_front(bd);
+
+        auto* adt = ad.data() + ad.data_offset();
+        auto* bdt = bd.data() + bd.data_offset();
+
+        // we need to have a pointer that points to the "real" start of the memory
+        // not to the first element (BLAS is doing that transformation itself)
+        if (stride_a < 0) {
+            adt += (ad.shape()[0] - 1) * stride_a; // go back to the start
+        }
+        if (stride_b < 0) {
+            bdt += (ad.shape()[0] - 1) * stride_b; // go back to the start
+        }
+
         cxxblas::dot<blas_index_t>(
             static_cast<blas_index_t>(ad.shape()[0]),
-            ad.data() + ad.data_offset(),
-            stride_front(ad),
-            bd.data() + bd.data_offset(),
-            stride_front(bd),
+            adt,
+            stride_a,
+            bdt,
+            stride_b,
             result
         );
     }
@@ -108,12 +123,27 @@ namespace blas
         auto&& bd = view_eval<E2::static_layout>(b.derived_cast());
         XTENSOR_ASSERT(ad.dimension() == 1);
 
+        blas_index_t stride_a = stride_front(ad);
+        blas_index_t stride_b = stride_front(bd);
+
+        auto* adt = ad.data() + ad.data_offset();
+        auto* bdt = bd.data() + bd.data_offset();
+
+        // we need to have a pointer that points to the "real" start of the memory
+        // not to the first element (BLAS is doing that transformation itself)
+        if (stride_a < 0) {
+            adt += (ad.shape()[0] - 1) * stride_a; // go back to the start
+        }
+        if (stride_b < 0) {
+            bdt += (ad.shape()[0] - 1) * stride_b; // go back to the start
+        }
+
         cxxblas::dotu<blas_index_t>(
             static_cast<blas_index_t>(ad.shape()[0]),
-            ad.data() + ad.data_offset(),
-            stride_front(ad),
-            bd.data() + bd.data_offset(),
-            stride_front(bd),
+            adt,
+            stride_a,
+            bdt,
+            stride_b,
             result
         );
     }

--- a/test/test_dot.cpp
+++ b/test/test_dot.cpp
@@ -202,7 +202,6 @@ namespace xt
         EXPECT_EQ(res3.dimension(), 2);
         EXPECT_EQ(res3.shape()[0], 3);
         EXPECT_EQ(res3.shape()[1], 3);
-
     }
 
 }

--- a/test/test_linalg.cpp
+++ b/test/test_linalg.cpp
@@ -579,4 +579,18 @@ namespace xt
 
         EXPECT_TRUE(allclose(expected4, res4));
     }
+
+    TEST(xlinalg, negative_strides)
+    {
+        xt::xarray<double> A = {{2, 3}, {5, 7}, {11, 13}};
+
+        auto A1 = xt::view(A, xt::range(0, 3), 0);
+        auto A2 = xt::view(A, xt::range(-1, -4, -1), 1);
+
+        auto res = xt::linalg::dot(A1, A2);
+        EXPECT_EQ(res(), 94);
+
+        
+    }
+
 }


### PR DESCRIPTION
This fixes the test case of #100 @kyungminlee 

Adding more tests would be good, though.