### PR TITLE
Fixing compiler warnings

### DIFF
--- a/include/xtensor-blas/xlapack.hpp
+++ b/include/xtensor-blas/xlapack.hpp
@@ -263,7 +263,7 @@ namespace lapack
         s.resize({ std::max(std::size_t(1), std::min(m, n)) });
 
         xtype2 u, vt;
-    
+
         blas_index_t u_stride, vt_stride;
         std::tie(u_stride, vt_stride) = detail::init_u_vt(u, vt, jobz, m, n);
 
@@ -471,7 +471,6 @@ namespace lapack
         XTENSOR_ASSERT(A.layout() == layout_type::column_major);
 
         using value_type = typename E::value_type;
-        using xtype = xtensor<value_type, 2, layout_type::column_major>;
 
         const auto N = A.shape()[0];
         uvector<value_type> work(1);
@@ -529,7 +528,6 @@ namespace lapack
         XTENSOR_ASSERT(A.layout() == layout_type::column_major);
 
         using value_type = typename E::value_type;
-        using xtype = xtensor<value_type, 2, layout_type::column_major>;
 
         auto N = A.shape()[0];
         uvector<value_type> work(1);
@@ -585,7 +583,6 @@ namespace lapack
 
         using value_type = typename E::value_type;
         using underlying_value_type = typename value_type::value_type;
-        using xtype = xtensor<value_type, 2, layout_type::column_major>;
 
         const auto N = A.shape()[0];
         uvector<value_type> work(1);
@@ -641,7 +638,6 @@ namespace lapack
 
         using value_type = typename E::value_type;
         using underlying_value_type = typename value_type::value_type;
-        using xtype = xtensor<value_type, 2, layout_type::column_major>;
 
         auto N = A.shape()[0];
         uvector<value_type> work(1);

--- a/include/xtensor-blas/xlinalg.hpp
+++ b/include/xtensor-blas/xlinalg.hpp
@@ -345,7 +345,6 @@ namespace linalg
     auto eig(const xexpression<E>& A)
     {
         using value_type = typename E::value_type;
-        using underlying_type = typename value_type::value_type;
 
         auto M = copy_to_layout<layout_type::column_major>(A.derived_cast());
 
@@ -923,7 +922,7 @@ namespace linalg
 
         uvector<blas_index_t> piv(std::min(LU.shape()[0], LU.shape()[1]));
 
-        int res = lapack::getrf(LU, piv);
+        lapack::getrf(LU, piv);
 
         value_type result(1);
         for (std::size_t i = 0; i < piv.size(); ++i)
@@ -1464,9 +1463,7 @@ namespace linalg
 
         blas_index_t rank;
 
-        int info = lapack::gelsd(dA, db, s, rank, rcond);
-
-        std::array<std::size_t, 1> residuals_shp = {0};
+        lapack::gelsd(dA, db, s, rank, rcond);
         auto residuals = xtensor<underlying_value_type, 1>::from_shape({0});
 
         if (std::size_t(rank) == N && M > N)


### PR DESCRIPTION
~~The unused option `rcond` in`xlinalg.hpp:lstsq` worries me a bit. Maybe it should be passed somewhere?~~