### PR TITLE
Add clang-cl support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,14 @@ set(XTENSOR_BLAS_HEADERS
 
 OPTION(CXXBLAS_DEBUG "print cxxblas debug information" OFF)
 OPTION(XTENSOR_USE_FLENS_BLAS "use FLENS generic implementation instead of cblas" OFF)
+# Decide whether to use OpenBLAS or not.
+# The user might have the folder containing OpenBLASConfig.cmake file
+# in the paths inspected by CMake already and just setting this to ON
+# would be enough to detect OpenBLAS.
+# If that is not the case, one can pass OpenBLAS_DIR without the boolean
+# toggle.
 OPTION(USE_OPENBLAS "use OpenBLAS (requires suitable OpenBLASConfig.cmake)" OFF)
-if(OpenBLASConfig_DIR)
+if(OpenBLAS_DIR)
   set(USE_OPENBLAS ON)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ set(XTENSOR_BLAS_HEADERS
 
 OPTION(CXXBLAS_DEBUG "print cxxblas debug information" OFF)
 OPTION(XTENSOR_USE_FLENS_BLAS "use FLENS generic implementation instead of cblas" OFF)
+OPTION(USE_OPENBLAS "use OpenBLAS (requires suitable OpenBLASConfig.cmake)" OFF)
+if(OpenBLASConfig_DIR)
+  set(USE_OPENBLAS ON)
+endif()
 
 if(XTENSOR_USE_FLENS_BLAS)
   add_definitions(-DXTENSOR_USE_FLENS_BLAS=1)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Travis](https://travis-ci.org/QuantStack/xtensor-blas.svg?branch=master)](https://travis-ci.org/QuantStack/xtensor-blas)
 [![Appveyor](https://ci.appveyor.com/api/projects/status/quf1hllkedr0rxbk?svg=true)](https://ci.appveyor.com/project/QuantStack/xtensor-blas)
+[![Azure](https://dev.azure.com/robertodr/xtensor-blas/_apis/build/status/robertodr.xtensor-blas?branchName=clang-cl)](https://dev.azure.com/robertodr/xtensor-blas/_build/latest?definitionId=8&branchName=clang-cl)
 [![Documentation](http://readthedocs.org/projects/xtensor-blas/badge/?version=latest)](https://xtensor-blas.readthedocs.io/en/latest/?badge=latest)
 [![Binder](https://img.shields.io/badge/launch-binder-brightgreen.svg)](https://mybinder.org/v2/gh/QuantStack/xtensor/stable?filepath=notebooks/xtensor.ipynb)
 [![Join the Gitter Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/QuantStack/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
                         gtest ^
                         mkl-devel ^
                         ninja ^
-                        xtensor=0.20.4 ^
+                        xtensor=0.20.6 ^
                         python=3.6
           conda list
         displayName: "Install conda packages"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,89 @@
+trigger:
+  - master
+
+jobs:
+
+  # Configure, build, install, and test job
+  - job: 'build'
+    pool:
+      vmImage: 'vs2015-win2012r2'
+    timeoutInMinutes: 360
+    steps:
+
+      # Install Chocolatey (https://chocolatey.org/install#install-with-powershellexe)
+      - powershell: |
+          Set-ExecutionPolicy Bypass -Scope Process -Force
+          iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+          Write-Host "##vso[task.setvariable variable=PATH]$env:PATH"
+          choco --version
+        displayName: "Install Chocolatey"
+
+      # Install Miniconda
+      - script: |
+          choco install miniconda3 --yes
+          set PATH=C:\tools\miniconda3\Scripts;C:\tools\miniconda3;C:\tools\miniconda3\Library\bin;%PATH%
+          echo '##vso[task.setvariable variable=PATH]%PATH%'
+          set LIB=C:\tools\miniconda3\Library\lib;%LIB%
+          echo '##vso[task.setvariable variable=LIB]%LIB%'
+          conda --version
+        displayName: "Install Miniconda"
+
+      # Configure Miniconda
+      - script: |
+          conda config --set always_yes yes
+          conda config --append channels conda-forge
+          conda info
+        displayName: "Configure Miniconda"
+
+      # Create conda enviroment
+      # Note: conda activate doesn't work here, because it creates a new shell!
+      - script: |
+          conda install cmake ^
+                        gtest ^
+                        mkl-devel ^
+                        ninja ^
+                        xtensor=0.20.4 ^
+                        python=3.6
+          conda list
+        displayName: "Install conda packages"
+
+      # Install LLVM
+      # Note: LLVM distributed by conda is too old
+      - script: |
+          choco install llvm --yes
+          set PATH=C:\Program Files\LLVM\bin;%PATH%
+          echo '##vso[task.setvariable variable=PATH]%PATH%'
+          clang-cl --version
+        displayName: "Install LLVM"
+
+      # Configure
+      - script: |
+          setlocal EnableDelayedExpansion
+          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          mkdir build & cd build
+          cmake -G Ninja ^
+                -DCMAKE_BUILD_TYPE=Release ^
+                -DCMAKE_C_COMPILER=clang-cl ^
+                -DCMAKE_CXX_COMPILER=clang-cl ^
+                -DBUILD_TESTS=ON ^
+                $(Build.SourcesDirectory)
+        displayName: "Configure xtensor-blas"
+        workingDirectory: $(Build.BinariesDirectory)
+
+      # Build
+      - script: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+          cmake --build . ^
+                --config Release ^
+                --target test_xtensor_blas ^
+                -- -v
+        displayName: "Build xtensor-blas"
+        workingDirectory: $(Build.BinariesDirectory)/build
+
+      # Test
+      - script: |
+          setlocal EnableDelayedExpansion
+          cd test
+          .\test_xtensor_blas
+        displayName: "Test xtensor-blas"
+        workingDirectory: $(Build.BinariesDirectory)/build/test

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.1)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-blas-test)
@@ -24,43 +24,51 @@ include(CheckCXXCompilerFlag)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-# C++14 is the earliest standard needed to compile
-set(CMAKE_CXX_STANDARD 14)
+include(set_compiler_flag.cmake)
+
 if(CPP17)
   # User requested C++17, but compiler might not oblige.
-  # Thus, we check availability of the flag.
-  CHECK_CXX_COMPILER_FLAG("-std=c++17" nonwin_HAS_CPP17_FLAG)
-  CHECK_CXX_COMPILER_FLAG("/std:c++17" win_HAS_CPP17_FLAG)
-  if(win_HAS_CPP17_FLAG OR nonwin_HAS_CPP17_FLAG)
+  set_compiler_flag(
+    _cxx_std_flag CXX
+    "-std=c++17"  # this should work with GNU, Intel, PGI
+    "/std:c++17"  # this should work with MSVC
+  )
+  if(_cxx_std_flag)
     message(STATUS "Building with C++17")
-    set(CMAKE_CXX_STANDARD 17)
-  else()
-    message(STATUS "Building with C++14")
   endif()
+else()
+  set_compiler_flag(
+    _cxx_std_flag CXX REQUIRED
+    "-std=c++14"  # this should work with GNU, Intel, PGI
+    "/std:c++14"  # this should work with MSVC
+  )
+  message(STATUS "Building with C++14")
 endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT _cxx_std_flag)
+  message(FATAL_ERROR "xtensor-blas needs a C++14-compliant compiler.")
+endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP /bigobj /wd4800")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} /EHsc /MP /bigobj /wd4800")
   set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
   add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if(NOT WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable")
   else() # We are using clang-cl
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP /bigobj /wd4800")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_cxx_std_flag} /EHsc /MP /bigobj")
     set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
   endif()
 else()
-  message(FATAL_ERROR "Unsupported compiler -- xtensor requires C++14 support!")
+  message(FATAL_ERROR "Unsupported compiler: ${CMAKE_CXX_COMPILER_ID}")
 endif()
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     project(xtensor-blas-test)
@@ -24,31 +24,43 @@ include(CheckCXXCompilerFlag)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
+# C++14 is the earliest standard needed to compile
+set(CMAKE_CXX_STANDARD 14)
+if(CPP17)
+  # User requested C++17, but compiler might not oblige.
+  # Thus, we check availability of the flag.
+  CHECK_CXX_COMPILER_FLAG("-std=c++17" nonwin_HAS_CPP17_FLAG)
+  CHECK_CXX_COMPILER_FLAG("/std:c++17" win_HAS_CPP17_FLAG)
+  if(win_HAS_CPP17_FLAG OR nonwin_HAS_CPP17_FLAG)
+    message(STATUS "Building with C++17")
+    set(CMAKE_CXX_STANDARD 17)
+  else()
+    message(STATUS "Building with C++14")
+  endif()
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP /bigobj /wd4800")
+  set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if(NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion -Wsign-conversion")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable")
-    #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter -Wextra -Wreorder -Wconversion")
-    CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
-    CHECK_CXX_COMPILER_FLAG("-std=c++17" HAS_CPP17_FLAG)
-
-    if (CPP17 AND HAS_CPP17_FLAG)
-        set(CMAKE_CXX_STANDARD 17)
-        message(STATUS "Building with -std=c++17")
-    elseif (HAS_CPP14_FLAG)
-        set(CMAKE_CXX_STANDARD 14)
-        message(STATUS "Building with -std=c++14")
-    else()
-        message(FATAL_ERROR "Unsupported compiler -- xtensor requires C++14 support!")
-    endif()
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
-if(MSVC)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+  else() # We are using clang-cl
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP /bigobj /wd4800")
     set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+  endif()
+else()
+  message(FATAL_ERROR "Unsupported compiler -- xtensor requires C++14 support!")
 endif()
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
@@ -90,7 +102,7 @@ include_directories(${XTENSOR_INCLUDE_DIR})
 include_directories(${XBLAS_INCLUDE_DIR})
 
 find_package(xtensor REQUIRED)
-if (WIN32)
+if(USE_OPENBLAS)
     find_package(OpenBLAS REQUIRED)
     set(BLAS_LIBRARIES ${CMAKE_INSTALL_PREFIX}${OpenBLAS_LIBRARIES})
 else()

--- a/test/set_compiler_flag.cmake
+++ b/test/set_compiler_flag.cmake
@@ -1,0 +1,66 @@
+# Copied from
+# https://github.com/dev-cafe/cmake-cookbook/blob/master/chapter-07/recipe-03/c-cxx-example/set_compiler_flag.cmake
+# Adapted from
+# https://github.com/robertodr/ddPCM/blob/expose-C-api/cmake/custom/compilers/SetCompilerFlag.cmake
+# which was adapted by Roberto Di Remigio from
+# https://github.com/SethMMorton/cmake_fortran_template/blob/master/cmake/Modules/SetCompileFlag.cmake
+
+# Given a list of flags, this stateless function will try each, one at a time,
+# and set result to the first flag that works.
+# If none of the flags works, result is "".
+# If the REQUIRED key is given and no flag is found, a FATAL_ERROR is raised.
+#
+# Call is:
+# set_compile_flag(result (Fortran|C|CXX) <REQUIRED> flag1 flag2 ...)
+#
+# Example:
+# set_compiler_flag(working_compile_flag C REQUIRED "-Wall" "-warn all")
+
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+include(CheckFortranCompilerFlag)
+
+function(set_compiler_flag _result _lang)
+  # build a list of flags from the arguments
+  set(_list_of_flags)
+  # also figure out whether the function
+  # is required to find a flag
+  set(_flag_is_required FALSE)
+  foreach(_arg IN ITEMS ${ARGN})
+    string(TOUPPER "${_arg}" _arg_uppercase)
+    if(_arg_uppercase STREQUAL "REQUIRED")
+      set(_flag_is_required TRUE)
+    else()
+      list(APPEND _list_of_flags "${_arg}")
+    endif()
+  endforeach()
+
+  set(_flag_found FALSE)
+  # loop over all flags, try to find the first which works
+  foreach(flag IN ITEMS ${_list_of_flags})
+
+    unset(_flag_works CACHE)
+    if(_lang STREQUAL "C")
+      check_c_compiler_flag("${flag}" _flag_works)
+    elseif(_lang STREQUAL "CXX")
+      check_cxx_compiler_flag("${flag}" _flag_works)
+    elseif(_lang STREQUAL "Fortran")
+      check_Fortran_compiler_flag("${flag}" _flag_works)
+    else()
+      message(FATAL_ERROR "Unknown language in set_compiler_flag: ${_lang}")
+    endif()
+
+    # if the flag works, use it, and exit
+    # otherwise try next flag
+    if(_flag_works)
+      set(${_result} "${flag}" PARENT_SCOPE)
+      set(_flag_found TRUE)
+      break()
+    endif()
+  endforeach()
+
+  # raise an error if no flag was found
+  if(_flag_is_required AND NOT _flag_found)
+    message(FATAL_ERROR "None of the required flags were supported")
+  endif()
+endfunction()


### PR DESCRIPTION
- Set up Azure pipeline to test clang-cl
- Fix test/CMakeLists.txt for new compiler. ~Note that I have bumped CMake minimum required version for the tests to 3.8. That's the version that learnt about C++17.~ I have reworked the check on C++ standard availability using [this](https://github.com/dev-cafe/cmake-cookbook/blob/master/chapter-07/recipe-03/README.md)
- On Azure, testing is done for linking against MKL downloaded from Conda. Probably the same could be done for Appveyor.

This is the [Azure build logs](https://dev.azure.com/robertodr/xtensor-blas/_build?definitionId=8&_a=summary)
You'll need an Azure free account and set up pipelines to actually use the YAML file. The badge in `README.md` should also be adjusted accordingly.