### PR TITLE
lapack.in.h: Use typedefs inside a namespace over macros

### DIFF
--- a/include/xflens/cxxlapack/netlib/interface/lapack.in.h
+++ b/include/xflens/cxxlapack/netlib/interface/lapack.in.h
@@ -2,34 +2,34 @@
 
 #ifndef INTEGER
 #    ifndef MKL_ILP64
-#        define INTEGER int
+typedef int INTEGER;
 #    else
-#        define INTEGER long
+typedef long INTEGER;
 #    endif
 #endif
 
 #ifndef FLOAT
-#define FLOAT float
+typedef float FLOAT;
 #endif
 
 #ifndef DOUBLE
-#define DOUBLE double
+typedef double DOUBLE;
 #endif
 
 #ifndef FLOAT_COMPLEX
-#define FLOAT_COMPLEX float
+typedef float FLOAT_COMPLEX;
 #endif
 
 #ifndef DOUBLE_COMPLEX
-#define DOUBLE_COMPLEX double
+typedef double DOUBLE_COMPLEX;
 #endif
 
 #ifndef LOGICAL
-#define LOGICAL int
+typedef int LOGICAL;
 #endif
 
 #ifndef UNKNOWN
-#define UNKNOWN void
+typedef void UNKNOWN;
 #endif
 
 //-- cbbcsd --------------------------------------------------------------------


### PR DESCRIPTION
This is a quick fix to stop the leakage of macros whose names are common C identifiers (tested).
Original issue arouse when I was indirectly including this header file with a header from dlib which makes use of the UNKNOWN enum member.
Fixes #121 